### PR TITLE
Implement mini jinja template engine: minja

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.9", "3.10", 3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", 3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ classifiers = [
 
   # Specify the Python versions you support here.
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 name = "snip"
 description = "A simple snippet tool"
 readme = "README.md"
-version = "0.1"
+version = "0.2"
 license = { file = "LICENSE" }
 keywords = ["cli", "snippet"]
 dependencies = []

--- a/snip/minja.py
+++ b/snip/minja.py
@@ -1,0 +1,47 @@
+"""
+Implement a simple template rendering because the default string.Template
+is missing function `get_identifiers()` for versions prior to 3.11. The
+name `minja` means to be a mini jinja engine.
+"""
+
+import re
+
+__all__ = ["Template"]
+
+
+NAME_PATTERN = re.compile(
+    r"""
+    {{                 # openning double braces
+    \s*                # any number of white spaces
+    (                  # begin group
+        [a-zA-Z_]      # first char of variable
+        [a-zA-Z0-9_]*  # subsequent chars
+    )                  # end group
+    \s*                # any number of white spaces
+    }}                 # closing double braces
+    """,
+    re.VERBOSE,
+)
+
+
+class Template:
+    """A simple Jinja-like template rendering class."""
+
+    def __init__(self, text=None):
+        self.text = text
+        self.names = []
+        self.table = {}
+
+    def load_text(self, text: str):
+        self.text = text
+        self.names = NAME_PATTERN.findall(text)
+
+    def render(self, **kwargs):
+        self.table = kwargs
+        out = NAME_PATTERN.sub(self._replace, self.text)
+        return out
+
+    def _replace(self, match: re.Match) -> str:
+        key = match[1]
+        out = str(self.table[key])
+        return out

--- a/snip/minja.py
+++ b/snip/minja.py
@@ -35,8 +35,7 @@ class Template:
 
     def load_text(self, text: str):
         self.text = text
-        if text is not None:
-            self.names = set(NAME_PATTERN.findall(text))
+        self.names = set(NAME_PATTERN.findall(text))
 
     def render(self, **kwargs):
         self.table = kwargs

--- a/snip/minja.py
+++ b/snip/minja.py
@@ -29,14 +29,14 @@ class Template:
     """A simple Jinja-like template rendering class."""
 
     def __init__(self, text: Optional[str] = None):
-        self.names = []
+        self.names = set()
         self.table = {}
-        self.load_text(text)
+        self.load_text(text or "")
 
-    def load_text(self, text: Optional[str] = None):
+    def load_text(self, text: str):
         self.text = text
         if text is not None:
-            self.names = NAME_PATTERN.findall(text)
+            self.names = set(NAME_PATTERN.findall(text))
 
     def render(self, **kwargs):
         self.table = kwargs

--- a/snip/minja.py
+++ b/snip/minja.py
@@ -5,6 +5,7 @@ name `minja` means to be a mini jinja engine.
 """
 
 import re
+from typing import Optional
 
 __all__ = ["Template"]
 
@@ -27,14 +28,15 @@ NAME_PATTERN = re.compile(
 class Template:
     """A simple Jinja-like template rendering class."""
 
-    def __init__(self, text=None):
-        self.text = text
+    def __init__(self, text: Optional[str] = None):
         self.names = []
         self.table = {}
+        self.load_text(text)
 
-    def load_text(self, text: str):
+    def load_text(self, text: Optional[str] = None):
         self.text = text
-        self.names = NAME_PATTERN.findall(text)
+        if text is not None:
+            self.names = NAME_PATTERN.findall(text)
 
     def render(self, **kwargs):
         self.table = kwargs

--- a/snip/snip.py
+++ b/snip/snip.py
@@ -5,10 +5,11 @@ import os
 import pathlib
 import platform
 import shlex
-import string
+import shutil
 import subprocess
 import tempfile
-import shutil
+
+from . import minja
 
 logging.config.fileConfig(pathlib.Path(__file__).with_name("logging.ini"))
 __all__ = ["get", "put"]
@@ -75,13 +76,13 @@ def put(name: str, root: pathlib.Path):
 
 def get(name: str, root: pathlib.Path, variables: dict):
     dest = root / name
-    template = string.Template(dest.read_text())
+    template = minja.Template(dest.read_text())
 
-    for name in template.get_identifiers():
+    for name in template.names:
         if name not in variables:
             variables[name] = input(f"{name}: ")
 
-    text = template.safe_substitute(variables)
+    text = template.render(**variables)
     print(text)
     copy_to_clipboard(text)
     return text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def text_file_name(root: pathlib.Path, plain_text):
 
 @pytest.fixture
 def template_text():
-    return "${flower} are ${color}"
+    return "{{flower}} are {{color}}"
 
 
 @pytest.fixture

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -19,10 +19,16 @@ def test_load_text():
 def test_load_text_should_set_names():
     template = Template()
     template.load_text("{{ flowers }} are {{ color }}")
-    assert template.names == ["flowers", "color"]
+    assert template.names == {"flowers", "color"}
 
 
 def test_initializer_should_set_names():
     """The initializer must call load_text."""
     template = Template("{{ flowers }} are {{ color }}")
-    assert template.names == ["flowers", "color"]
+    assert template.names == {"flowers", "color"}
+
+
+def test_no_duplicate_names():
+    """Names should be a set, hence no duplicates."""
+    template = Template("{{ a }}, {{ b }}, {{ a }}")
+    assert template.names == {"a", "b"}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -14,3 +14,15 @@ def test_load_text():
     template = Template()
     template.load_text("My alias is {{ alias }}")
     assert template.render(alias="anna") == "My alias is anna"
+
+
+def test_load_text_should_set_names():
+    template = Template()
+    template.load_text("{{ flowers }} are {{ color }}")
+    assert template.names == ["flowers", "color"]
+
+
+def test_initializer_should_set_names():
+    """The initializer must call load_text."""
+    template = Template("{{ flowers }} are {{ color }}")
+    assert template.names == ["flowers", "color"]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,16 @@
+"""
+Test the Template class.
+"""
+
+from snip.minja import Template
+
+
+def test_simple():
+    template = Template("{{ flowers }} are {{ color }}")
+    assert template.render(color="red", flowers="Roses") == "Roses are red"
+
+
+def test_load_text():
+    template = Template()
+    template.load_text("My alias is {{ alias }}")
+    assert template.render(alias="anna") == "My alias is anna"


### PR DESCRIPTION
The `string.Template` does not have the function `get_identifiers()` until version 3.11. Since I want this package to work with 3.9, I created my own engine.
