### PR TITLE
Add a configuration file

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -31,7 +31,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with ruff
       run: |
-        ruff check .
+        ruff check --output-format=github .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -27,8 +27,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest pytest-pythonpath
+        pip install -r requirements-dev.txt
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with ruff
+      run: |
+        ruff check .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - I would be nice if we can display the file using `bat`
 
 # Backlog
+- Fix the required Python version -> 3.9
 - config file
 - Include first run
 - Sensible default

--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # Nice to Have
-- Integrate with fzf to select snippets
+- Integration with fzf
+- Integration with bat
+- Integration with jq
 - Tags
 - Keep a database for metadata (tags, ...)
 - I would be nice if we can display the file using `bat`
 
 # Backlog
-- Fix the required Python version -> 3.9
-- config file
-- Include first run
-- Sensible default
-- Q: Should we ask for a directory to store snippet, or just assume some place?
-- first run: ask where to store snippets
 - Add github workflow to `hatchling build` package for the release
+- Add docs for the tool
+- Add github workflow to upload doc to `readthedocs.com`
 
 # History
 
@@ -21,3 +19,12 @@
 - Implement simple put, get
 - Copy to clipboard
 - Add simple template expansion
+
+2024-09-02
+
+- Fix the required Python version -> 3.9
+- Add config file
+- Include first run, which create the config file if not found
+- Sensible default
+    - config file: `~/.config/snip.json`
+    - data dir: `~/.local/share/snip`

--- a/README.md
+++ b/README.md
@@ -1,24 +1,21 @@
-# Goals
-- Create a command-line interface (CLI) snip tool
-- Actions: CRUD
-- Configuration file
-    - Where to store database
-- Tags
-- template expansion
-- Copy to clipboard
+# Nice to Have
 - Integrate with fzf to select snippets
-- Each snippet stored in 1 file
+- Tags
 - Keep a database for metadata (tags, ...)
-- Python installable package
 - I would be nice if we can display the file using `bat`
 
 # Backlog
 - config file
+- Include first run
+- Sensible default
+- Q: Should we ask for a directory to store snippet, or just assume some place?
 - first run: ask where to store snippets
+- Add github workflow to `hatchling build` package for the release
 
 # History
 
-## 2024-09-01
+2024-09-01
+
 - Create an installable package
 - Implement simple put, get
 - Copy to clipboard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "0.2"
 license = { file = "LICENSE" }
 keywords = ["cli", "snippet"]
 dependencies = []
-requires-python = ">= 3.11"
+requires-python = ">= 3.9"
 authors = [
     {name = "Hai Vu", email="haivu2004@gmail.com"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 name = "snip"
 description = "A simple snippet tool"
 readme = "README.md"
-version = "0.2"
+version = "0.3"
 license = { file = "LICENSE" }
 keywords = ["cli", "snippet"]
 dependencies = []
@@ -21,7 +21,7 @@ classifiers = [
   #   3 - Alpha
   #   4 - Beta
   #   5 - Production/Stable
-  "Development Status :: 4 - Beta",
+  "Development Status :: 3 - Alpha",
 
   # Indicate who your project is intended for
   "Intended Audience :: Developers",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+flake8
 pytest
 pytest-pythonpath
 ruff

--- a/snip/cli.py
+++ b/snip/cli.py
@@ -4,6 +4,7 @@ import logging.config
 import pathlib
 
 from . import snip
+from .config import DATA_DIR, load
 
 
 def main():
@@ -20,9 +21,8 @@ def main():
     options = parser.parse_args()
     logging.debug("options: %r", options)
 
-    # TODO: Do not hard code, get from config or ask
-    root = pathlib.Path("~/Sync/snip").expanduser()
-    root.mkdir(exist_ok=True)
+    config = load()
+    root = pathlib.Path(config[DATA_DIR])
 
     if options.action == "put":
         snip.put(options.filename, root)

--- a/snip/config.py
+++ b/snip/config.py
@@ -1,0 +1,30 @@
+import json
+import pathlib
+
+DATA_DIR = "data-dir"
+DEFAULT_DATA_DIR = pathlib.Path("~/.local/share/snip").expanduser()
+DEFAULT_CONFIG = {DATA_DIR: str(DEFAULT_DATA_DIR)}
+
+
+def load() -> dict:
+    """
+    Load the configuration file.
+
+    :return: The configuration
+    """
+    config_path = pathlib.Path("~/.config/snip.json").expanduser()
+
+    if not config_path.exists():
+        with open(config_path, "w", encoding="utf-8") as stream:
+            json.dump(DEFAULT_CONFIG, stream, indent=4)
+
+    with open(config_path, "r", encoding="utf-8") as stream:
+        config = json.load(stream)
+
+    # Ensure this key exists
+    config.setdefault(DATA_DIR, str(DEFAULT_DATA_DIR))
+
+    # Ensure the data dir exists
+    pathlib.Path(config[DATA_DIR]).mkdir(exist_ok=True)
+
+    return config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,10 +40,9 @@ def template_text_file(root: pathlib.Path, template_text: str):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def preserve_config():
+def preserve_config(config_path):
     """Preserve the real ~/.config/snip.json."""
     # Save state
-    config_path = pathlib.Path("~/.config/snip.json").expanduser()
     config_found = config_path.exists()
     saved_content = ""
     if config_found:
@@ -56,3 +55,10 @@ def preserve_config():
         config_path.write_text(saved_content)
     else:
         config_path.unlink(missing_ok=True)
+
+
+@pytest.fixture(scope="session")
+def config_path():
+    """The path to the config file."""
+    path = pathlib.Path("~/.config/snip.json").expanduser()
+    return path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,3 +37,22 @@ def template_text_file(root: pathlib.Path, template_text: str):
     path.write_text(template_text)
     yield path.name
     path.unlink()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def preserve_config():
+    """Preserve the real ~/.config/snip.json."""
+    # Save state
+    config_path = pathlib.Path("~/.config/snip.json").expanduser()
+    config_found = config_path.exists()
+    saved_content = ""
+    if config_found:
+        saved_content = config_path.read_text()
+
+    yield
+
+    # Restore
+    if config_found:
+        config_path.write_text(saved_content)
+    else:
+        config_path.unlink(missing_ok=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,49 @@
+import json
+import pathlib
+
+from snip.config import load
+
+CONFIG_PATH = pathlib.Path("~/.config/snip.json").expanduser()
+
+
+def config_prep(tmp_path):
+    config_path = pathlib.Path("~/.config/snip.json").expanduser()
+    data_dir = tmp_path / "data_dir"
+
+    config = {
+        "data-dir": str(data_dir),
+        "extra": True,
+    }
+    with open(config_path, "w", encoding="utf-8") as stream:
+        json.dump(config, stream)
+
+    return config_path
+
+
+def test_config_not_exist():
+    """Test load behavior when config file does not exist"""
+
+    # Pre: Ensure config file does not exist
+    CONFIG_PATH.unlink(missing_ok=True)
+
+    # Act
+    config = load()
+
+    # Verify
+    assert CONFIG_PATH.exists()
+    assert isinstance(config, dict)
+    assert "data-dir" in config
+    assert pathlib.Path(config["data-dir"]).exists()
+
+
+def test_config_exists(tmp_path):
+    """Load config when config file exists."""
+    # Pre: Ensure a custom config exist
+    config_prep(tmp_path)
+
+    config = load()
+
+    # Verify
+    assert CONFIG_PATH.exists()
+    assert pathlib.Path(config["data-dir"]).exists()
+    assert config["extra"] is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,47 +3,42 @@ import pathlib
 
 from snip.config import load
 
-CONFIG_PATH = pathlib.Path("~/.config/snip.json").expanduser()
 
+def test_config_exists(tmp_path, config_path):
+    """Load config when config file exists."""
 
-def config_prep(tmp_path):
-    config_path = pathlib.Path("~/.config/snip.json").expanduser()
-    data_dir = tmp_path / "data_dir"
-
-    config = {
-        "data-dir": str(data_dir),
-        "extra": True,
-    }
+    # Pre: Ensure a custom config exist
+    data_dir = str(tmp_path / "snip-data")
     with open(config_path, "w", encoding="utf-8") as stream:
-        json.dump(config, stream)
-
-    return config_path
-
-
-def test_config_not_exist():
-    """Test load behavior when config file does not exist"""
-
-    # Pre: Ensure config file does not exist
-    CONFIG_PATH.unlink(missing_ok=True)
+        json.dump(
+            {
+                "data-dir": data_dir,
+                "extra": True,
+            },
+            stream,
+        )
 
     # Act
     config = load()
 
     # Verify
-    assert CONFIG_PATH.exists()
-    assert isinstance(config, dict)
-    assert "data-dir" in config
+    assert config_path.exists()
     assert pathlib.Path(config["data-dir"]).exists()
+    assert config["data-dir"] == str(data_dir)
+    assert config["extra"] is True
 
 
-def test_config_exists(tmp_path):
-    """Load config when config file exists."""
-    # Pre: Ensure a custom config exist
-    config_prep(tmp_path)
+def test_config_not_exist(config_path):
+    """Load config when config file does not exist"""
 
+    # Pre: Ensure config file does not exist
+    config_path.unlink(missing_ok=True)
+
+    # Act
     config = load()
 
     # Verify
-    assert CONFIG_PATH.exists()
+    assert config_path.exists()
+    assert isinstance(config, dict)
+    assert "data-dir" in config
     assert pathlib.Path(config["data-dir"]).exists()
-    assert config["extra"] is True


### PR DESCRIPTION
Currently, I use ~/Sync/snip to store snippets. There are a couple of issues with this:
- People might want to store it elsewhere
- That lead to the ability to configure this directory

The solution is to create a config file at `~/.config/snip.json`, by default, it looks like this:

```json
{
    "data-dir": "/Users/user1/.local/share/snip"
}
```
