### PR TITLE
Manually update version, no longer use hatchling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,18 +15,7 @@ format:
 	uv run ruff format .
 
 version:
-	@echo "Version reported by snip:"
-	@uv run snip --version
-
-	@echo ""
-	@echo "Version reported by hatchling:"
-	@uv run hatchling version
-
-	@echo ""
-	@echo To set the version, run 
-	@echo "    uv run hatchling version <new>"
-	@echo "For example:"
-	@echo "    uv run hatchling version 0.5.14"
+	uv run snip --version
 
 clean:
 	find . -name '*.pyc' -delete

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,11 +1,15 @@
 # History
 
-2024-09-01
+version 0.5.1 2024-12-10
+- Switch tooling to uv
+- Introduce the ls sub command
 
-- Create an installable package
-- Implement simple put, get
-- Copy to clipboard
-- Add simple template expansion
+Version 0.4.2 2024-09-03
+- Fix pyproject.toml to work with `hatchling build`
+
+Version 0.4.1 2024-09-03
+- Integration with fzf
+- Add `--version` flags
 
 version 0.3 2024-09-02
 
@@ -16,9 +20,10 @@ version 0.3 2024-09-02
     - config file: `~/.config/snip.json`
     - data dir: `~/.local/share/snip`
 
-Version 0.4.1 2024-09-03
-- Integration with fzf
-- Add `--version` flags
+2024-09-01
 
-Version 0.4.2 2024-09-03
-- Fix pyproject.toml to work with `hatchling build`
+- Create an installable package
+- Implement simple put, get
+- Copy to clipboard
+- Add simple template expansion
+

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,6 +1,10 @@
 # History
 
-version 0.5.1 2024-12-10
+Version 0.5.2 2024-12-10
+- Use static version
+- Single truth in pyproject.toml
+
+Version 0.5.1 2024-12-10
 - Switch tooling to uv
 - Introduce the ls sub command
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,10 +1,9 @@
 # Road Map
 
 ## Backlog
-- Add github workflow to `hatchling build` package for the release
 - Publish to readthedocs
 
 ## Nice to Have
-- Integration with bat
+- Integration with bat, or use rich library
 - Integration with jq
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = []
-dynamic = ["version"]
+version = "0.5.2"
 
 [project.scripts]
 snip = "snip.cli:main"
@@ -24,7 +24,4 @@ dev = [
     "pytest-pythonpath>=0.7.3",
     "ruff>=0.8.2",
 ]
-
-[tool.hatch.version]
-path = "src/snip/__init__.py"
 

--- a/src/snip/__init__.py
+++ b/src/snip/__init__.py
@@ -1,10 +1,5 @@
 from .snip import get, ls, put
 
-# Do not edit __version__ directly
-# Show: uv run hatchling version
-# Set: uv run hatchling version 0.5.3
-__version__ = "0.5.1"
-
 __all__ = [
     "get",
     "ls",

--- a/src/snip/cli.py
+++ b/src/snip/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib.metadata
 import logging
 import logging.config
 import os
@@ -7,7 +8,7 @@ import shutil
 import subprocess
 import tempfile
 
-from . import __version__, config, snip
+from . import config, snip
 
 
 def select_file(root: pathlib.Path):
@@ -36,7 +37,10 @@ def select_file(root: pathlib.Path):
 def parse_command_line():
     parser = argparse.ArgumentParser(prog="snip")
     parser.add_argument(
-        "-v", "--version", action="version", version="%(prog)s " + __version__
+        "-v",
+        "--version",
+        action="version",
+        version="%(prog)s " + importlib.metadata.version("snip"),
     )
     sub_parser = parser.add_subparsers(dest="action", required=True)
 

--- a/todo.txt
+++ b/todo.txt
@@ -1,2 +1,3 @@
 - Error when directory is not found or empty, get
 - Tests do not preserve symlink file
+- Use click

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "snip"
-version = "0.5.0"
+version = "0.5.9"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -165,7 +165,7 @@ wheels = [
 
 [[package]]
 name = "snip"
-version = "0.5.9"
+version = "0.5.2"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
# Work Items

- Use static version
- The single truth for version is in pyproject under project/version
- Simplify Makefile 